### PR TITLE
Add: option to install with a custom mongodbUrl.

### DIFF
--- a/reactioncommerce/templates/configmap.yaml
+++ b/reactioncommerce/templates/configmap.yaml
@@ -8,4 +8,8 @@ data:
   reaction.auth: {{ .Values.reactionAuth }}
   reaction.root_url: {{ .Values.reactionRoot_url }}
   reaction.hostname: {{ .Values.reactionHostname }}
+  {{- if eq .Values.mongodbUrl ""}}
   reaction.mongo_url: {{ template "mongodb_replicaset_url" . }}
+  {{- else}}
+  reaction.mongo_url: {{ .Values.mongodbUrl }}
+  {{- end}}

--- a/reactioncommerce/values.yaml
+++ b/reactioncommerce/values.yaml
@@ -42,7 +42,7 @@ mongodbReleaseName: 'massive-mongonetes'
 mongodbName: 'reactionetesdb'
 mongodbReplicaSet: 'rs0'
 mongodbPort: 27017
-mongodbUrl: 'mongodb://{{ .Values.mongodbReleaseName }}-mongodb-replicaset-0:{{ .Values.mongodbPort }},{{ .Values.mongodbReleaseName }}-mongodb-replicaset-1:{{ .Values.mongodbPort }},{{ .Values.mongodbReleaseName }}-mongodb-replicaset-2:{{ .Values.mongodbPort }}/{{ .Values.mongodbName }}?replicaSet={{ .Values.mongodbReplicaSet }} '
+mongodbUrl: ''
 
 # reaction specific values
 reactioncommerceClusterDomain: 'cluster.local'


### PR DESCRIPTION
Previously the chart was always trying to recreate the replicaset's url and with this change one can supply any url (even if it is not a replicaset) and the old functionality is still there if the user doesn't provide a url.